### PR TITLE
Fix username slug to use '-' instead of '.'

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -2,7 +2,10 @@ from django.db import models
 from django.contrib.auth.models import AbstractUser
 
 class CustomUser(AbstractUser):
-    pass
+    
+    def save(self, *args, **kwargs):
+        self.username = self.username.replace('.','-')
+        super().save(*args, **kwargs)
 
     def get_freelancer(self):
         # print('checking freelancer')

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,3 +1,15 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-# Create your tests here.
+User = get_user_model()
+
+
+
+class TestFreelanceModel(TestCase):
+    def setUp(self):
+        user = User.objects.create_user(username="test.user",password="password",email="test@mail.com")
+        self.user = user
+
+    def test_user_model_username(self):
+        self.assertNotEqual(self.user.username, 'test.user')
+        self.assertEqual(self.user.username, 'test-user')


### PR DESCRIPTION
Attempts to fix: #13 

Changes made:
* Username will now use '-' instead of '.' in order to avoid URL issue.
* Added test case